### PR TITLE
Remove unused token with ill-formed regex

### DIFF
--- a/yajco-example-mathExpressions/src/main/java/yajco/example/expression/model/package-info.java
+++ b/yajco-example-mathExpressions/src/main/java/yajco/example/expression/model/package-info.java
@@ -6,7 +6,6 @@
         @TokenDef(name = "MINUS", regexp = "[-]"),
         @TokenDef(name = "STAR", regexp = "[*]"),
         @TokenDef(name = "SLASH", regexp = "[/]"),
-        @TokenDef(name = "POW", regexp = "[^]"),
         @TokenDef(name = "VALUE", regexp = "([0-9]+)")
     },
     skips = {


### PR DESCRIPTION
The _mathExpressions_ example defines a token with an ill-formed regular expression (specifically, the caret is not escaped) that triggers runtime errors in my parser generator module. Since the token is unused anyway, I have removed it.